### PR TITLE
Add Workflow : auto deploy to preview channel when pull request created.

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,49 @@
+name: Preview PR Changes
+on:
+  pull_request:
+    branches:
+      - staging
+env:
+  CI: false
+  PROJECT_ID: "${{ secrets.STAGING_PROJECT_ID }}"
+  GCP_SA_KEY: "${{ secrets.GCP_SA_STAGING_KEY }}"
+  PR_NUMBER: ${{ github.event.pull_request.number }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+      - name: Set NodeJS version
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.17.0'
+      - name: Install Dependencies and Build
+        run: |
+          npm install
+          echo "REACT_APP_BASE_URL=${{ secrets.REACT_STAGING_APP_BASE_URL }}" >> .env
+          echo "REACT_APP_API_URL=${{ secrets.REACT_STAGING_APP_API_URL }}" >> .env
+          npm run build
+      - name: Archive Production Artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: build
+          path: build
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+      - name: Download Artifact
+        uses: actions/download-artifact@master
+        with:
+          name: build
+          path: build
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: hosting:channel:deploy review_${{ env.PR_NUMBER }}


### PR DESCRIPTION
當有新的 PR 開啟（或是有新的 commit push 上來），且合併目標為 `staging` 的時候觸發 workflow 建置及部署至設定的 firebase preview channel 上

此 preview link 預設 7 天到期，詳情請參考 [Firebase 的文件](https://firebase.google.com/docs/hosting/manage-hosting-resources)


**已知問題**
- workflow log 上可以看到 preview link ，但因為 firebase project id 有設定成 secrets ，所以連結部分內容被替換掉了 (可參考[這邊](https://github.com/unciax/coromap/actions/runs/979385817)的執行結果)